### PR TITLE
fix: handle lab stop and image test regressions

### DIFF
--- a/voglander-integration/src/main/java/io/github/lunasaw/voglander/intergration/wrapper/gb28181/lab/LabMediaPushService.java
+++ b/voglander-integration/src/main/java/io/github/lunasaw/voglander/intergration/wrapper/gb28181/lab/LabMediaPushService.java
@@ -482,7 +482,9 @@ public class LabMediaPushService {
         }
         /* 清理待处理的流上线等待 */
         String streamId = props.getZlmStream();
-        CompletableFuture<Void> future = pendingStreamReadyFutures.remove(streamId);
+        CompletableFuture<Void> future = StringUtils.isNotBlank(streamId)
+            ? pendingStreamReadyFutures.remove(streamId)
+            : null;
         if (future != null && !future.isDone()) {
             future.cancel(true);
             log.debug("Lab 取消流上线等待, streamId={}", streamId);

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/image/ImageCollectionApplicationServiceTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/image/ImageCollectionApplicationServiceTest.java
@@ -42,7 +42,7 @@ class ImageCollectionApplicationServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         service = new ImageCollectionApplicationService(taskCreateService, configManager, deviceManager,
-            channelManager, new ImageProperties());
+            channelManager, new ImageProperties(), taskManager);
     }
 
     @Test


### PR DESCRIPTION
## Problem

- Lab media shutdown could remove a pending future with a blank stream ID, which is invalid for the concurrent map.
- `ImageCollectionApplicationServiceTest` was not updated after `BizTaskManager` became a constructor dependency.

## Solution

- Guard pending-future removal with a non-blank stream ID check.
- Inject the existing `BizTaskManager` mock into the application service test fixture.

## Verification

- `git diff --check`
- Targeted Maven test was started but not completed before direct submission was requested.

## Impact

No schema, configuration, or protocol compatibility changes.