### PR TITLE
feat(image): complete backend readiness and open SSE topics

### DIFF
--- a/voglander-service/src/main/java/io/github/lunasaw/voglander/service/sse/SseDeliveryAuthorizer.java
+++ b/voglander-service/src/main/java/io/github/lunasaw/voglander/service/sse/SseDeliveryAuthorizer.java
@@ -1,36 +1,15 @@
 package io.github.lunasaw.voglander.service.sse;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONObject;
-
-/** Shared local/Redis delivery decision for an immutable subscription context. */
+/** Shared local/Redis topic-matching decision for an authenticated subscription. */
 @Component
 public class SseDeliveryAuthorizer {
 
     public boolean allow(SseSubscriptionContext context, SseEvent event) {
-        if (context == null || event == null || !matches(context.getTopics(), event.getTopic())) return false;
-        String root = SseSubscriptionContext.rootOf(event.getTopic());
-        if ("image.asset".equals(root)) return context.isImageAssetQueryAllowed();
-        if (!"business.task".equals(root)) return true;
-        if (context.isTaskQueryAllowed()) return true;
-        String taskType = taskType(event.getData());
-        return taskType != null && context.isImageCollectionQueryAllowed()
-            && context.getAllowedTaskTypes() != null && context.getAllowedTaskTypes().contains(taskType);
-    }
-
-    private String taskType(Object data) {
-        if (data instanceof Map<?, ?>) {
-            Object value = ((Map<?, ?>)data).get("taskType");
-            return value == null ? null : String.valueOf(value);
-        }
-        if (data == null) return null;
-        JSONObject object = JSON.parseObject(JSON.toJSONString(data));
-        return object == null ? null : object.getString("taskType");
+        return context != null && event != null && matches(context.getTopics(), event.getTopic());
     }
 
     private boolean matches(Set<String> subscribed, String topic) {

--- a/voglander-service/src/main/java/io/github/lunasaw/voglander/service/sse/SseSubscriptionContext.java
+++ b/voglander-service/src/main/java/io/github/lunasaw/voglander/service/sse/SseSubscriptionContext.java
@@ -1,8 +1,6 @@
 package io.github.lunasaw.voglander.service.sse;
 
 import java.util.Collections;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -11,47 +9,19 @@ import org.springframework.util.StringUtils;
 
 import io.github.lunasaw.voglander.common.exception.ServiceException;
 import io.github.lunasaw.voglander.common.exception.ServiceExceptionEnum;
-import lombok.Builder;
 import lombok.Value;
 
-/** Immutable authorization snapshot retained only for one SSE connection. */
+/** Immutable authenticated subscription retained only for one SSE connection. */
 @Value
-@Builder(toBuilder = true)
 public class SseSubscriptionContext {
-    private static final Set<String> ALLOWED_ROOTS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
-        "business.task", "image.asset", "device", "live", "alarm")));
-
     String emitterId;
     String userId;
     Set<String> topics;
-    boolean taskQueryAllowed;
-    boolean imageCollectionQueryAllowed;
-    boolean imageAssetQueryAllowed;
-    Set<String> allowedTaskTypes;
 
-    public static SseSubscriptionContext authorized(String userId, Set<String> topics,
-        boolean taskQueryAllowed, boolean imageCollectionQueryAllowed, boolean imageAssetQueryAllowed) {
+    public static SseSubscriptionContext authorized(String userId, Set<String> topics) {
         if (!StringUtils.hasText(userId)) throw invalidSubscription();
         Set<String> normalized = normalize(topics);
-        for (String topic : normalized) {
-            String root = rootOf(topic);
-            if (!ALLOWED_ROOTS.contains(root)) throw invalidSubscription();
-            if ("business.task".equals(root) && !taskQueryAllowed && !imageCollectionQueryAllowed) {
-                throw invalidSubscription();
-            }
-            if ("image.asset".equals(root) && !imageAssetQueryAllowed) throw invalidSubscription();
-        }
-        Set<String> allowedTypes = taskQueryAllowed ? null
-            : imageCollectionQueryAllowed ? Collections.singleton("IMAGE_COLLECTION") : Collections.emptySet();
-        return SseSubscriptionContext.builder()
-            .emitterId(UUID.randomUUID().toString())
-            .userId(userId)
-            .topics(normalized)
-            .taskQueryAllowed(taskQueryAllowed)
-            .imageCollectionQueryAllowed(imageCollectionQueryAllowed)
-            .imageAssetQueryAllowed(imageAssetQueryAllowed)
-            .allowedTaskTypes(allowedTypes)
-            .build();
+        return new SseSubscriptionContext(UUID.randomUUID().toString(), userId, normalized);
     }
 
     private static Set<String> normalize(Set<String> topics) {
@@ -60,14 +30,6 @@ public class SseSubscriptionContext {
         for (String topic : topics) if (StringUtils.hasText(topic)) result.add(topic.trim());
         if (result.isEmpty()) throw invalidSubscription();
         return Collections.unmodifiableSet(result);
-    }
-
-    static String rootOf(String topic) {
-        if (topic == null) return "";
-        if (topic.equals("business.task") || topic.startsWith("business.task.")) return "business.task";
-        if (topic.equals("image.asset") || topic.startsWith("image.asset.")) return "image.asset";
-        int separator = topic.indexOf('.');
-        return separator < 0 ? topic : topic.substring(0, separator);
     }
 
     private static ServiceException invalidSubscription() {

--- a/voglander-service/src/main/java/io/github/lunasaw/voglander/service/task/BusinessTaskAuthorizationService.java
+++ b/voglander-service/src/main/java/io/github/lunasaw/voglander/service/task/BusinessTaskAuthorizationService.java
@@ -12,7 +12,6 @@ import io.github.lunasaw.voglander.common.exception.ServiceException;
 import io.github.lunasaw.voglander.common.exception.ServiceExceptionEnum;
 import io.github.lunasaw.voglander.manager.domaon.dto.UserDTO;
 import io.github.lunasaw.voglander.manager.domaon.dto.task.BizTaskAccessScopeDTO;
-import io.github.lunasaw.voglander.service.sse.SseSubscriptionContext;
 
 /** Creates trusted task scopes and enforces task-type-specific control permissions. */
 @Service
@@ -57,14 +56,6 @@ public class BusinessTaskAuthorizationService {
     public boolean hasTaskControlWithoutImageControl(UserDTO actor) {
         return hasPermission(actor, TaskConstant.PERMISSION_CONTROL)
             && !hasPermission(actor, ImageConstant.PERMISSION_COLLECTION_CONTROL);
-    }
-
-    public SseSubscriptionContext sseContext(UserDTO actor, Set<String> topics) {
-        if (actor == null || actor.getId() == null) throw denied();
-        return SseSubscriptionContext.authorized(actor.getId().toString(), topics,
-            hasPermission(actor, TaskConstant.PERMISSION_QUERY),
-            hasPermission(actor, ImageConstant.PERMISSION_COLLECTION_QUERY),
-            hasPermission(actor, ImageConstant.PERMISSION_ASSET_QUERY));
     }
 
     public boolean hasPermission(UserDTO actor, String permission) {

--- a/voglander-web/src/main/java/io/github/lunasaw/voglander/web/api/sse/controller/SseController.java
+++ b/voglander-web/src/main/java/io/github/lunasaw/voglander/web/api/sse/controller/SseController.java
@@ -13,7 +13,6 @@ import io.github.lunasaw.voglander.common.constant.ApiConstant;
 import io.github.lunasaw.voglander.manager.domaon.dto.UserDTO;
 import io.github.lunasaw.voglander.service.sse.SseEventBus;
 import io.github.lunasaw.voglander.service.sse.SseSubscriptionContext;
-import io.github.lunasaw.voglander.service.task.BusinessTaskAuthorizationService;
 import io.github.lunasaw.voglander.web.api.auth.AuthenticatedUserResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,26 +25,22 @@ public class SseController {
 
     private final SseEventBus sseEventBus;
     private final AuthenticatedUserResolver authenticatedUserResolver;
-    private final BusinessTaskAuthorizationService authorizationService;
 
     @Autowired
-    public SseController(SseEventBus sseEventBus, AuthenticatedUserResolver authenticatedUserResolver,
-        BusinessTaskAuthorizationService authorizationService) {
+    public SseController(SseEventBus sseEventBus, AuthenticatedUserResolver authenticatedUserResolver) {
         this.sseEventBus = sseEventBus;
         this.authenticatedUserResolver = authenticatedUserResolver;
-        this.authorizationService = authorizationService;
     }
 
     @GetMapping(value = "/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "订阅实时事件流")
     public SseEmitter subscribe(
-            @Parameter(description = "逗号分隔的主题 allowlist：device、live、alarm、business.task、image.asset；"
-                + "business.task 和 image.asset 需相应查询权限，服务端还会逐事件校验权限")
+            @Parameter(description = "逗号分隔的事件主题或主题前缀；登录用户可订阅任意非空主题")
             @RequestParam(defaultValue = "device,live,alarm") String topics,
             @RequestParam(required = false) String token) {
         UserDTO actor = authenticatedUserResolver.resolveToken(token);
         Set<String> topicSet = new HashSet<>(Arrays.asList(topics.split(",")));
-        SseSubscriptionContext context = authorizationService.sseContext(actor, topicSet);
+        SseSubscriptionContext context = SseSubscriptionContext.authorized(actor.getId().toString(), topicSet);
         return sseEventBus.register(context);
     }
 }

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/RealRedisSseEventBusIntegrationTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/RealRedisSseEventBusIntegrationTest.java
@@ -2,7 +2,6 @@ package io.github.lunasaw.voglander.service.sse;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -55,7 +54,7 @@ class RealRedisSseEventBusIntegrationTest {
     }
 
     @Test
-    void realRedisDeliversLocallyAndRemotelyOnceWithIdenticalAuthorization() throws Exception {
+    void realRedisDeliversAllMatchingTopicsLocallyAndRemotelyOnce() {
         SseEmitterTestCapture local = register(firstBus, "local-user");
         SseEmitterTestCapture remote = register(secondBus, "remote-user");
 
@@ -66,10 +65,11 @@ class RealRedisSseEventBusIntegrationTest {
         assertEquals(1, occurrences(local.dump(), "allowed-real-redis"));
         assertEquals(1, occurrences(remote.dump(), "allowed-real-redis"));
 
-        firstBus.publish(taskEvent("DATA_EXPORT", "denied-real-redis"));
-        Thread.sleep(250);
-        assertFalse(local.dump().contains("denied-real-redis"));
-        assertFalse(remote.dump().contains("denied-real-redis"));
+        firstBus.publish(taskEvent("DATA_EXPORT", "export-real-redis"));
+        await().atMost(Duration.ofSeconds(3))
+            .until(() -> remote.dump().contains("export-real-redis"));
+        assertEquals(1, occurrences(local.dump(), "export-real-redis"));
+        assertEquals(1, occurrences(remote.dump(), "export-real-redis"));
     }
 
     private LettuceConnectionFactory connectionFactory() {
@@ -89,7 +89,7 @@ class RealRedisSseEventBusIntegrationTest {
 
     private SseEmitterTestCapture register(RedisBackedSseEventBus bus, String userId) {
         SseSubscriptionContext context = SseSubscriptionContext.authorized(userId,
-            Collections.singleton("business.task"), false, true, false);
+            Collections.singleton("business.task"));
         SseEmitter emitter = bus.register(context);
         SseEmitterTestCapture capture = new SseEmitterTestCapture();
         capture.attach(emitter);

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseDeliveryAuthorizerTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseDeliveryAuthorizerTest.java
@@ -1,11 +1,13 @@
 package io.github.lunasaw.voglander.service.sse;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,42 +18,34 @@ class SseDeliveryAuthorizerTest {
     private final SseDeliveryAuthorizer authorizer = new SseDeliveryAuthorizer();
 
     @Test
-    void imageCollectionSubscriberOnlyReceivesImageCollectionTaskEvents() {
-        SseSubscriptionContext context = SseSubscriptionContext.builder()
-            .userId("7")
-            .topics(Collections.singleton("business.task"))
-            .imageCollectionQueryAllowed(true)
-            .allowedTaskTypes(Collections.singleton("IMAGE_COLLECTION"))
-            .build();
+    void deliveryUsesOnlyExactOrDottedPrefixTopicMatching() {
+        SseSubscriptionContext context = SseSubscriptionContext.authorized("7",
+            Collections.singleton("business.task"));
 
-        assertTrue(authorizer.allow(context, event("IMAGE_COLLECTION")));
-        assertFalse(authorizer.allow(context, event("DATA_EXPORT")));
-        assertFalse(authorizer.allow(context, new SseEvent("business.task.state", Collections.emptyMap())));
+        assertTrue(authorizer.allow(context,
+            new SseEvent("business.task.state", Collections.singletonMap("taskType", "DATA_EXPORT"))));
+        assertFalse(authorizer.allow(context,
+            new SseEvent("business.tasks", Collections.emptyMap())));
+        assertFalse(authorizer.allow(context,
+            new SseEvent("image.asset.created", Collections.emptyMap())));
     }
 
     @Test
-    void assetEventsRequireAssetQueryPermission() {
-        SseSubscriptionContext denied = SseSubscriptionContext.builder()
-            .userId("7")
-            .topics(Collections.singleton("image.asset"))
-            .build();
-        SseSubscriptionContext allowed = denied.toBuilder().imageAssetQueryAllowed(true).build();
+    void arbitraryTopicRootsAreAcceptedAndDelivered() {
+        SseSubscriptionContext context = SseSubscriptionContext.authorized("7",
+            Collections.singleton("future-domain"));
 
-        SseEvent event = new SseEvent("image.asset.created", Collections.emptyMap());
-        assertFalse(authorizer.allow(denied, event));
-        assertTrue(authorizer.allow(allowed, event));
+        assertTrue(authorizer.allow(context,
+            new SseEvent("future-domain.created", Collections.emptyMap())));
     }
 
     @Test
-    void subscriptionRejectsUnknownAndEmptyTopics() {
-        assertThrows(ServiceException.class,
-            () -> SseSubscriptionContext.authorized("7", Collections.singleton("unknown.topic"), true,
-                false, false));
-        assertThrows(ServiceException.class,
-            () -> SseSubscriptionContext.authorized("7", Collections.emptySet(), true, false, false));
-    }
+    void subscriptionNormalizesTopicsAndRejectsOnlyAnEmptyResult() {
+        SseSubscriptionContext context = SseSubscriptionContext.authorized("7",
+            new HashSet<>(Arrays.asList(" future-domain ", "future-domain", " ")));
 
-    private SseEvent event(String taskType) {
-        return new SseEvent("business.task.state", Map.of("taskType", taskType));
+        assertEquals(Collections.singleton("future-domain"), context.getTopics());
+        assertThrows(ServiceException.class,
+            () -> SseSubscriptionContext.authorized("7", Collections.singleton(" ")));
     }
 }

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseDomainMetricsWiringTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseDomainMetricsWiringTest.java
@@ -16,7 +16,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 class SseDomainMetricsWiringTest {
 
     @Test
-    void localAndRedisRecordTheSameLifecycleAuthorizationAndFailureMetrics() {
+    void localAndRedisRecordTheSameLifecycleFilteringAndFailureMetrics() {
         assertMetrics("LOCAL");
         assertMetrics("REDIS");
     }
@@ -37,8 +37,7 @@ class SseDomainMetricsWiringTest {
         capture.attach(emitter);
         assertEquals(1.0, registry.get("sse_emitter_count").tag("bus_type", busType).gauge().value());
 
-        bus.publishLocal(new SseEvent("business.task.state",
-            Map.of("taskType", "DATA_EXPORT", "marker", "filtered")));
+        bus.publishLocal(new SseEvent("image.asset.created", Map.of("marker", "filtered")));
         assertEquals(1.0, registry.get("sse_delivery_filtered_total")
             .tag("bus_type", busType).counter().count());
         capture.triggerCompletion();
@@ -55,7 +54,6 @@ class SseDomainMetricsWiringTest {
     }
 
     private SseSubscriptionContext context(String userId) {
-        return SseSubscriptionContext.authorized(userId, Collections.singleton("business.task"),
-            false, true, false);
+        return SseSubscriptionContext.authorized(userId, Collections.singleton("business.task"));
     }
 }

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseEmitterLifecycleTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseEmitterLifecycleTest.java
@@ -17,28 +17,28 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitterTestCaptu
 class SseEmitterLifecycleTest {
 
     @Test
-    void completionTimeoutAndErrorReleaseLocalAuthorizationSnapshots() {
+    void completionTimeoutAndErrorReleaseLocalSubscriptionContexts() {
         assertLifecycle(new LocalSseEventBus(new SseDeliveryAuthorizer()));
     }
 
     @Test
-    void completionTimeoutAndErrorReleaseRedisAuthorizationSnapshots() {
+    void completionTimeoutAndErrorReleaseRedisSubscriptionContexts() {
         RedisBackedSseEventBus bus = new RedisBackedSseEventBus(new SseDeliveryAuthorizer());
         ReflectionTestUtils.setField(bus, "stringRedisTemplate", mock(StringRedisTemplate.class));
         assertLifecycle(bus);
     }
 
     @Test
-    void heartbeatIsOnlyPingAndDoesNotBypassBusinessAuthorization() {
+    void heartbeatIsOnlyPingAndDoesNotBypassTopicFiltering() {
         LocalSseEventBus bus = new LocalSseEventBus(new SseDeliveryAuthorizer());
         SseEmitterTestCapture capture = register(bus, "heartbeat");
 
         bus.heartbeat();
-        bus.publishLocal(new SseEvent("business.task.state",
-            Map.of("taskType", "DATA_EXPORT", "marker", "forbidden-business-event")));
+        bus.publishLocal(new SseEvent("image.asset.created",
+            Map.of("marker", "unsubscribed-event")));
 
         assertTrue(capture.dump().contains("ping"));
-        assertFalse(capture.dump().contains("forbidden-business-event"));
+        assertFalse(capture.dump().contains("unsubscribed-event"));
         assertEquals(1, bus.emitterCount());
     }
 
@@ -82,7 +82,7 @@ class SseEmitterLifecycleTest {
 
     private SseEmitterTestCapture register(SseEventBus bus, String userId) {
         SseSubscriptionContext context = SseSubscriptionContext.authorized(userId,
-            Collections.singleton("business.task"), false, true, false);
+            Collections.singleton("business.task"));
         SseEmitter emitter = bus.register(context);
         SseEmitterTestCapture capture = new SseEmitterTestCapture();
         capture.attach(emitter);

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseEventBusAuthorizationTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseEventBusAuthorizationTest.java
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitterTestCaptu
 class SseEventBusAuthorizationTest {
 
     @Test
-    void localAndRedisDeliveryApplyTheSameTaskTypeAuthorization() {
+    void localAndRedisDeliveryDoNotFilterByTaskType() {
         assertDelivery(new LocalSseEventBus(new SseDeliveryAuthorizer()), false);
         assertDelivery(redisBus(), false);
         assertDelivery(redisBus(), true);
@@ -30,40 +30,40 @@ class SseEventBusAuthorizationTest {
         RedisBackedSseEventBus bus = redisBus();
         StringRedisTemplate redis = (StringRedisTemplate)ReflectionTestUtils.getField(bus, "stringRedisTemplate");
         SseSubscriptionContext context = SseSubscriptionContext.authorized("42",
-            Collections.singleton("business.task"), false, true, false);
+            Collections.singleton("business.task"));
         bus.register(context);
 
         bus.publish(taskEvent("IMAGE_COLLECTION", "allowed"));
 
         ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
         verify(redis).convertAndSend(eq("sse:broadcast"), json.capture());
-        assertFalse(json.getValue().contains(context.getEmitterId()));
-        assertFalse(json.getValue().contains(context.getUserId()));
-        assertFalse(json.getValue().contains("allowedTaskTypes"));
+        for (String subscriptionField : new String[] {"emitterId", "userId", "topics", "allowedTaskTypes"}) {
+            assertFalse(json.getValue().contains("\"" + subscriptionField + "\""));
+        }
     }
 
     private void assertDelivery(SseEventBus bus, boolean remote) {
         SseEmitterTestCapture capture = new SseEmitterTestCapture();
         SseSubscriptionContext context = SseSubscriptionContext.authorized("7",
-            Collections.singleton("business.task"), false, true, false);
+            Collections.singleton("business.task"));
         SseEmitter emitter = bus.register(context);
         capture.attach(emitter);
 
         if (remote) {
             RedisBackedSseEventBus redis = (RedisBackedSseEventBus)bus;
-            SseEvent allowed = taskEvent("IMAGE_COLLECTION", "allowed");
-            allowed.setOriginId("remote-node");
-            redis.handleRemote(allowed);
-            SseEvent denied = taskEvent("DATA_EXPORT", "denied");
-            denied.setOriginId("remote-node");
-            redis.handleRemote(denied);
+            SseEvent collection = taskEvent("IMAGE_COLLECTION", "collection");
+            collection.setOriginId("remote-node");
+            redis.handleRemote(collection);
+            SseEvent export = taskEvent("DATA_EXPORT", "export");
+            export.setOriginId("remote-node");
+            redis.handleRemote(export);
         } else {
-            bus.publishLocal(taskEvent("IMAGE_COLLECTION", "allowed"));
-            bus.publishLocal(taskEvent("DATA_EXPORT", "denied"));
+            bus.publishLocal(taskEvent("IMAGE_COLLECTION", "collection"));
+            bus.publishLocal(taskEvent("DATA_EXPORT", "export"));
         }
 
-        assertTrue(capture.dump().contains("allowed"));
-        assertFalse(capture.dump().contains("denied"));
+        assertTrue(capture.dump().contains("collection"));
+        assertTrue(capture.dump().contains("export"));
     }
 
     private RedisBackedSseEventBus redisBus() {

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseEventBusTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseEventBusTest.java
@@ -87,6 +87,6 @@ public class SseEventBusTest extends BaseTest {
     }
 
     private SseSubscriptionContext context(String userId, String topic) {
-        return SseSubscriptionContext.authorized(userId, new HashSet<>(Set.of(topic)), true, true, true);
+        return SseSubscriptionContext.authorized(userId, new HashSet<>(Set.of(topic)));
     }
 }

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseOriginSuppressionTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/service/sse/SseOriginSuppressionTest.java
@@ -78,6 +78,6 @@ class SseOriginSuppressionTest {
     }
 
     private SseSubscriptionContext context(String userId, String topic) {
-        return SseSubscriptionContext.authorized(userId, new HashSet<>(Set.of(topic)), true, true, true);
+        return SseSubscriptionContext.authorized(userId, new HashSet<>(Set.of(topic)));
     }
 }

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/web/api/SseControllerTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/web/api/SseControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,7 +18,6 @@ import io.github.lunasaw.voglander.manager.domaon.dto.UserDTO;
 import io.github.lunasaw.voglander.manager.service.AuthService;
 import io.github.lunasaw.voglander.service.sse.SseEventBus;
 import io.github.lunasaw.voglander.service.sse.SseSubscriptionContext;
-import io.github.lunasaw.voglander.service.task.BusinessTaskAuthorizationService;
 import io.github.lunasaw.voglander.web.api.auth.AuthenticatedUserResolver;
 import io.github.lunasaw.voglander.web.api.sse.controller.SseController;
 
@@ -33,8 +31,7 @@ class SseControllerTest {
     MockMvc mvc;
 
     @BeforeEach void setup() {
-        controller = new SseController(sseEventBus, new AuthenticatedUserResolver(authService),
-            new BusinessTaskAuthorizationService());
+        controller = new SseController(sseEventBus, new AuthenticatedUserResolver(authService));
         mvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -57,7 +54,7 @@ class SseControllerTest {
     }
 
     @Test
-    void subscribe_neverUsesOpaqueTokenAsEmitterIdentity() throws Exception {
+    void subscribe_acceptsArbitraryTopicsWithoutPermissionsAndNeverUsesTokenAsIdentity() throws Exception {
         UserDTO user = new UserDTO();
         user.setId(42L);
         user.setPermissions(java.util.Collections.emptyList());
@@ -68,11 +65,14 @@ class SseControllerTest {
 
         mvc.perform(get("/api/v1/stream/events")
                 .param("token", "secret-token-value")
-                .param("topics", "device,live"))
+                .param("topics", "device,session,clientcmd,alarm,future-domain"))
             .andExpect(status().isOk());
 
         verify(sseEventBus).register(context.capture());
         org.junit.jupiter.api.Assertions.assertEquals("42", context.getValue().getUserId());
+        org.junit.jupiter.api.Assertions.assertEquals(
+            java.util.Set.of("device", "session", "clientcmd", "alarm", "future-domain"),
+            context.getValue().getTopics());
         org.junit.jupiter.api.Assertions.assertFalse(
             context.getValue().getEmitterId().contains("secret-token-value"));
     }

--- a/voglander-web/src/test/java/io/github/lunasaw/voglander/web/api/image/ImageOpenApiContractTest.java
+++ b/voglander-web/src/test/java/io/github/lunasaw/voglander/web/api/image/ImageOpenApiContractTest.java
@@ -55,7 +55,7 @@ class ImageOpenApiContractTest {
     }
 
     @Test
-    void idempotencyExpectedVersionAndSseAuthorizationAreExplicit() throws Exception {
+    void idempotencyExpectedVersionAndSseSubscriptionContractAreExplicit() throws Exception {
         Method upload = ImageAssetController.class.getDeclaredMethod("upload", String.class, String.class,
             MultipartFile.class, String.class);
         assertIdempotencyHeader(upload.getParameters()[1]);
@@ -69,7 +69,7 @@ class ImageOpenApiContractTest {
         Method subscribe = SseController.class.getDeclaredMethod("subscribe", String.class, String.class);
         Parameter topics = subscribe.getParameters()[0].getAnnotation(Parameter.class);
         assertNotNull(topics);
-        for (String required : new String[] {"device", "live", "alarm", "business.task", "image.asset", "权限"}) {
+        for (String required : new String[] {"主题前缀", "登录用户", "任意", "非空主题"}) {
             assertTrue(topics.description().contains(required), "SSE OpenAPI 缺少 " + required);
         }
     }


### PR DESCRIPTION
## Problem

The dev branch contains the image asset collection backend readiness work and runtime hardening that are not yet in master. SSE subscriptions also rejected topics outside a fixed allowlist and applied per-user task/image filtering, leaving new event topics unusable until more permission UI was built.

## Changes

- Complete image asset collection backend readiness and related API contracts.
- Harden media lifecycle and restart behavior.
- Keep token authentication while allowing any non-blank SSE topic or topic prefix.
- Preserve exact and dotted-prefix event matching.
- Remove SSE-only permission and task-type filtering without changing REST, menu, task, or image permissions.
- Document the open-topic subscription design; no dynamic configuration page is introduced.

## Verification

- mvn clean compile (pass)
- SSE and OpenAPI contract regression: 29 tests, 0 failures, 0 errors, 3 environment skips
- Full mvn test executed: 1321 tests; non-SSE failures are confined to SIP E2E tests because the local SIP ListeningPoint is not running
- git diff --check (pass)

## Compatibility

Authenticated SSE clients may now subscribe to existing topics such as device, session, clientcmd, and alarm, as well as future non-empty topics. REST and menu authorization behavior is unchanged.